### PR TITLE
Regional Europe/Asia buckets support (tests included)

### DIFF
--- a/lib/aws/s3/base.rb
+++ b/lib/aws/s3/base.rb
@@ -43,6 +43,13 @@ module AWS #:nodoc:
   module S3
     constant :DEFAULT_HOST, 's3.amazonaws.com'
     
+    # See: http://docs.amazonwebservices.com/AmazonS3/latest/dev/index.html?RequestEndpoints.html
+    ENDPOINTS = {
+      :us     => 's3-us-west-1.amazonaws.com', 
+      :asia   => 's3-ap-southeast-1.amazonaws.com', 
+      :europe => 's3-eu-west-1.amazonaws.com'
+    }
+    
     # AWS::S3::Base is the abstract super class of all classes who make requests against S3, such as the built in
     # Service, Bucket and S3Object classes. It provides methods for making requests, inferring or setting response classes,
     # processing request options, and accessing attributes from S3's response data.

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -212,6 +212,23 @@ class ConnectionOptionsTest < Test::Unit::TestCase
     assert options.connecting_through_proxy?
   end
   
+  def test_server_and_region_settings_cant_live_together
+    assert_raises(ArgumentError) do
+      generate_options(:region => :europe, :server => "example.org")
+    end
+  end
+  
+  def test_server_setting_is_extracted_from_region
+    options = generate_options(:region => :europe)
+    assert_equal ENDPOINTS[:europe], options[:server]
+  end
+  
+  def test_region_is_a_valid_s3_endpoint
+    assert_raises(ArgumentError) do
+      generate_options(:region => :antartica)
+    end
+  end
+  
   private
     def assert_key_transfered(key, value, options)
       assert_equal value, options[key]


### PR DESCRIPTION
Buckets in europe/asia require a different server, this commits solves the problem described in:
http://github.com/marcel/aws-s3/issues#issue/4

introducing enpoints as in aws/s3 documentation:
http://docs.amazonwebservices.com/AmazonS3/latest/dev/index.html?RequestEndpoints.html

The commit includes tests and documentation update.

Thanks, many people gets that error,
Elia
