### PR TITLE
Update object with unicode characters

### DIFF
--- a/lib/aws/s3/object.rb
+++ b/lib/aws/s3/object.rb
@@ -191,7 +191,7 @@ module AWS
         def update(key, bucket = nil, options = {})
           bucket          = bucket_name(bucket)
           source_key      = path!(bucket, key)
-          default_options = {'x-amz-copy-source' => source_key, 'x-amz-metadata-directive' => 'REPLACE'}
+          default_options = {'x-amz-copy-source' => URI.encode(source_key), 'x-amz-metadata-directive' => 'REPLACE'}
           returning put(source_key, options.merge(default_options)) do
             acl(key, bucket, acl(key, bucket))
           end

--- a/lib/aws/s3/object.rb
+++ b/lib/aws/s3/object.rb
@@ -179,7 +179,7 @@ module AWS
         def copy(key, copy_key, bucket = nil, options = {})
           bucket          = bucket_name(bucket)
           source_key      = path!(bucket, key)
-          default_options = {'x-amz-copy-source' => source_key}
+          default_options = {'x-amz-copy-source' => URI.escape(source_key)}
           target_key      = path!(bucket, copy_key)
           returning put(target_key, default_options) do
             acl(copy_key, bucket, acl(key, bucket)) if options[:copy_acl]

--- a/test/remote/object_test.rb
+++ b/test/remote/object_test.rb
@@ -176,6 +176,26 @@ class RemoteS3ObjectTest < Test::Unit::TestCase
     assert_equal object.value, copy.value
     assert_equal object.content_type, copy.content_type
     
+    # Test copy to an filename with an accent
+    copy_to_accent = nil
+    assert_nothing_raised do
+      object.copy('testing_s3objects-copy-to-accent-é')
+      copy_to_accent = S3Object.find('testing_s3objects-copy-to-accent-é', TEST_BUCKET)
+      assert        copy_to_accent
+      assert_equal  copy_to_accent.value,         object.value
+      assert_equal  copy_to_accent.content_type,  object.content_type
+    end
+    
+    # Test copy from an filename with an accent
+    assert_nothing_raised do
+      object_with_accent = S3Object.find('testing_s3objects-copy-to-accent-é')
+      object_with_accent.copy('testing_s3objects-copy-from-accent')
+      copy_from_accent = S3Object.find('testing_s3objects-copy-from-accent', TEST_BUCKET)
+      assert        copy_from_accent
+      assert_equal  copy_from_accent.value,         object_with_accent.value
+      assert_equal  copy_from_accent.content_type,  object_with_accent.content_type
+    end    
+    
     # Delete object
     
     assert_nothing_raised do

--- a/test/remote/object_test.rb
+++ b/test/remote/object_test.rb
@@ -400,6 +400,23 @@ class RemoteS3ObjectTest < Test::Unit::TestCase
     S3Object.delete(key, TEST_BUCKET)
   end
 
+  def test_updating_an_object_with_unicode_name
+    key = 'ʇɔǝɾqo-pǝʇɐpdn'
+
+    S3Object.store(key, 'value does not matter', TEST_BUCKET)
+    object = S3Object.find(key, TEST_BUCKET)
+
+    object.content_type = 'foo/bar'
+    object.metadata[:foo] = 'bar'
+    object.update
+
+    reloaded_object = S3Object.find(key, TEST_BUCKET)
+    assert_equal 'foo/bar', reloaded_object.content_type
+    assert_equal 'bar', reloaded_object.metadata[:foo]
+  ensure
+    S3Object.delete(key, TEST_BUCKET)
+  end
+
   private
     def fetch_object_at(url)
       Net::HTTP.get_response(URI.parse(url))


### PR DESCRIPTION
Without these two commits, I would get the error "The request signature we calculated does not match the signature you provided. Check your key and signing method." with keys containing unicode characters.
