### PR TITLE
Add dependencies to gemspec.

### DIFF
--- a/aws-s3.gemspec
+++ b/aws-s3.gemspec
@@ -8,4 +8,8 @@ Gem::Specification.new do |s|
 
   s.files = %w(CHANGELOG COPYING INSTALL Rakefile) + Dir['lib/**/*'] + Dir["bin/*"]
   s.require_path = 'lib'
+
+  s.add_runtime_dependency 'builder'
+  s.add_runtime_dependency 'mime-types'
+  s.add_runtime_dependency 'xml-simple'
 end


### PR DESCRIPTION
When the gemspec was added, the dependencies from the Rakefile weren't carried over into the gemspec. Specifically, a runtime error was occurring since XMLSimple was no longer considered a dependency by Bundler.
