### PR TITLE
Add support for overriding s3 responses

### DIFF
--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -102,6 +102,11 @@ class ConnectionTest < Test::Unit::TestCase
     assert authenticated[connection.url_for('/foo', :authenticated => true)]
     assert !authenticated[connection.url_for('/foo', :authenticated => false)]
   end
+
+  def test_url_for_with_response_override_options
+    connection = Connection.new(:access_key_id => '123', :secret_access_key => 'abc', :port => 80)
+    assert_match %r(^http://s3\.amazonaws\.com/foo\?AWSAccessKeyId=.*&Expires=.*&response-content-disposition=attachment;filename=foo.bar), connection.url_for('/foo', {'response-content-disposition' => 'attachment;filename=foo.bar'})
+  end
   
   def test_connecting_through_a_proxy
     connection = nil


### PR DESCRIPTION
Adds support for overriding s3 responses when using the S3Object.url_for method. s3 supports overriding the following response headers: response-content-type, response-content-language, response-expires, reponse-cache-control, response-content-disposition, and response-content-encoding. This allows you to, for instance, download a single s3 file as either an attachment or inline, instead of having to store two objects, each with a different content-dispostion.
